### PR TITLE
feat(card): add base mobile styles and input validation behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -113,7 +113,8 @@ html {
 body {
   min-height: 100vh;
   background-color: var(--BGCOLOR);
-  color: var(--FONT-COLOR);
+  /* ! TO DELETE COLOR RED */
+  color: red;
 }
 
 /** || HEADER */

--- a/css/style.css
+++ b/css/style.css
@@ -193,6 +193,14 @@ body {
   width: 100%;
 }
 
+.card__picture {
+  width: 100%;
+}
+
+.card__hero {
+  width: 100%;
+}
+
 /** || MEDIA QUERY (DEVICE WIDTH) */
 @media screen and (min-width: 23.4375rem) {
 }

--- a/css/style.css
+++ b/css/style.css
@@ -61,12 +61,14 @@ ol {
 
   /* COLORS */
   --BGCOLOR-CARD: #fff;
+  --BGCOLOR-CARD-SUBSCRIBE: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LABEL: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-INVALID: hsl(4, 100%, 67%);
   --FONT-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
+  --FONT-COLOR-CARD-SUBSCRIBE: #fff;
   --COLOR-CARD-ICON: #ff6155;
   --BORDER-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
 
@@ -295,6 +297,17 @@ body {
   padding: 1.1em 1.5em;
   width: 100%;
   border-radius: 8px;
+}
+
+.card__subscribe {
+  background-color: var(--BGCOLOR-CARD-SUBSCRIBE);
+  color: var(--FONT-COLOR-CARD-SUBSCRIBE);
+  font-weight: 700;
+  width: 100%;
+  border-radius: 8px;
+  padding: 1.1em;
+  user-select: none;
+  cursor: pointer;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,7 @@ ol {
   /* COLORS */
   --BGCOLOR-CARD: #fff;
   --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
+  --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
 
   /* THEME TOGGLE COLORS */
   --FONT-COLOR-THEME-ICON-LIGHT: #333;
@@ -210,6 +211,12 @@ body {
   font-weight: 700;
   color: var(--FONT-COLOR-CARD-TITLE);
   font-size: 2.5rem;
+}
+
+.card__description {
+  font-weight: 400;
+  color: var(--FONT-COLOR-CARD-DESCRIPTION);
+  line-height: 1.5;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -264,8 +264,10 @@ body {
 .card__label-container {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
+  position: relative;
+  width: 100%;
 }
 
 .card__label {
@@ -278,6 +280,10 @@ body {
   color: var(--FONT-COLOR-CARD-INVALID);
   font-weight: 700;
   font-size: 0.75rem;
+  position: absolute;
+  display: block;
+  min-width: max-content;
+  right: 0;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -123,7 +123,7 @@ body {
   border-radius: 50px;
   position: absolute;
   top: 1rem;
-  right: 1rem;
+  left: 1rem;
   padding: 0.5em 1em;
   display: flex;
   flex-direction: row;

--- a/css/style.css
+++ b/css/style.css
@@ -174,6 +174,13 @@ body {
 }
 
 /** || MAIN */
+.main__container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  min-height: 100vh;
+}
 
 /** || MEDIA QUERY (DEVICE WIDTH) */
 @media screen and (min-width: 23.4375rem) {

--- a/css/style.css
+++ b/css/style.css
@@ -273,6 +273,7 @@ body {
   align-items: center;
   position: relative;
   width: 100%;
+  margin-block-end: 0.6em;
 }
 
 .card__label {
@@ -297,6 +298,7 @@ body {
   padding: 1.1em 1.5em;
   width: 100%;
   border-radius: 8px;
+  margin-block-end: 1.5em;
 }
 
 .card__subscribe {

--- a/css/style.css
+++ b/css/style.css
@@ -230,6 +230,7 @@ body {
   flex-direction: column;
   justify-content: space-between;
   gap: 0.725em;
+  margin-block-end: 2.6em;
 }
 
 .card__list {

--- a/css/style.css
+++ b/css/style.css
@@ -66,7 +66,9 @@ ol {
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LABEL: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-INVALID: hsl(4, 100%, 67%);
+  --FONT-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
   --COLOR-CARD-ICON: #ff6155;
+  --BORDER-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
 
   /* THEME TOGGLE COLORS */
   --FONT-COLOR-THEME-ICON-LIGHT: #333;
@@ -77,6 +79,7 @@ ol {
 
   /* BORDERS */
   --BORDER-THEME-BUTTON: 1px solid var(--BORDER-COLOR-THEME-BUTTON);
+  --BORDER-CARD-INPUT: 1px solid var(--BORDER-COLOR-CARD-INPUT);
 
   /* SHADOWS */
   --BOX-SHADOW-THEME: 0 0 3px var(--SHADOW-COLOR-THEME);
@@ -284,6 +287,14 @@ body {
   display: block;
   min-width: max-content;
   right: 0;
+}
+
+.card__input {
+  border: var(--BORDER-CARD-INPUT);
+  color: var(--FONT-COLOR-CARD-INPUT);
+  padding: 1.1em 1.5em;
+  width: 100%;
+  border-radius: 8px;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -220,6 +220,7 @@ body {
   font-weight: 400;
   color: var(--FONT-COLOR-CARD-DESCRIPTION);
   line-height: 1.5;
+  margin-block-end: 1.65em;
 }
 
 .card__features {

--- a/css/style.css
+++ b/css/style.css
@@ -64,6 +64,7 @@ ol {
   --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
+  --COLOR-CARD-ICON: #ff6155;
 
   /* THEME TOGGLE COLORS */
   --FONT-COLOR-THEME-ICON-LIGHT: #333;
@@ -232,7 +233,13 @@ body {
   flex-direction: row;
   justify-content: flex-start;
   align-items: flex-start;
-  gap: 1em;
+  gap: 0.9em;
+}
+
+.card__icon {
+  color: var(--COLOR-CARD-ICON);
+  width: 24px;
+  height: auto;
 }
 
 .card__list-text {

--- a/css/style.css
+++ b/css/style.css
@@ -60,7 +60,7 @@ ol {
   --FS: 1rem;
 
   /* COLORS */
-  --BGCOLOR: #fff;
+  --BGCOLOR-CARD: #fff;
   --FONT-COLOR: #000;
 
   /* THEME TOGGLE COLORS */
@@ -188,6 +188,7 @@ body {
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+  background-color: var(--BGCOLOR-CARD);
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -253,6 +253,13 @@ body {
   line-height: 1.45;
 }
 
+.card__form {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
 .card__label-container {
   display: flex;
   flex-direction: row;

--- a/css/style.css
+++ b/css/style.css
@@ -65,6 +65,7 @@ ol {
   --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LABEL: hsl(234, 29%, 20%);
+  --FONT-COLOR-CARD-INVALID: hsl(4, 100%, 67%);
   --COLOR-CARD-ICON: #ff6155;
 
   /* THEME TOGGLE COLORS */
@@ -254,6 +255,12 @@ body {
 
 .card__label {
   color: var(--FONT-COLOR-CARD-LABEL);
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+.card__invalid {
+  color: var(--FONT-COLOR-CARD-INVALID);
   font-weight: 700;
   font-size: 0.75rem;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -61,7 +61,7 @@ ol {
 
   /* COLORS */
   --BGCOLOR-CARD: #fff;
-  --FONT-COLOR: #000;
+  --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
 
   /* THEME TOGGLE COLORS */
   --FONT-COLOR-THEME-ICON-LIGHT: #333;
@@ -199,6 +199,12 @@ body {
 
 .card__hero {
   width: 100%;
+}
+
+.card__title {
+  font-weight: 700;
+  color: var(--FONT-COLOR-CARD-TITLE);
+  font-size: 2.5rem;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -253,6 +253,13 @@ body {
   line-height: 1.45;
 }
 
+.card__label-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .card__label {
   color: var(--FONT-COLOR-CARD-LABEL);
   font-weight: 700;

--- a/css/style.css
+++ b/css/style.css
@@ -226,6 +226,14 @@ body {
   justify-content: space-between;
 }
 
+.card__list {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 1em;
+}
+
 /** || MEDIA QUERY (DEVICE WIDTH) */
 @media screen and (min-width: 23.4375rem) {
 }

--- a/css/style.css
+++ b/css/style.css
@@ -186,9 +186,11 @@ body {
 .card {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   background-color: var(--BGCOLOR-CARD);
+  min-height: 100vh;
+  width: 100%;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -63,6 +63,7 @@ ol {
   --BGCOLOR-CARD: #fff;
   --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
+  --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
 
   /* THEME TOGGLE COLORS */
   --FONT-COLOR-THEME-ICON-LIGHT: #333;
@@ -232,6 +233,12 @@ body {
   justify-content: flex-start;
   align-items: flex-start;
   gap: 1em;
+}
+
+.card__list-text {
+  color: var(--FONT-COLOR-CARD-LIST-TEXT);
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -67,7 +67,8 @@ ol {
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LABEL: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-INVALID: hsl(4, 100%, 67%);
-  --FONT-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
+  --FONT-COLOR-CARD-INPUT: hsl(235, 18%, 26%);
+  --FONT-COLOR-CARD-INPUT-PLACEHOLDER: hsl(0, 0%, 58%);
   --FONT-COLOR-CARD-SUBSCRIBE: #fff;
   --COLOR-CARD-ICON: #ff6155;
   --BORDER-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
@@ -300,6 +301,10 @@ body {
   width: 100%;
   border-radius: 8px;
   margin-block-end: 1.5em;
+}
+
+.card__input::placeholder {
+  color: var(--FONT-COLOR-CARD-INPUT-PLACEHOLDER);
 }
 
 .card__subscribe {

--- a/css/style.css
+++ b/css/style.css
@@ -201,6 +201,11 @@ body {
   width: 100%;
 }
 
+.card__content {
+  padding-block-start: 2.25rem;
+  padding-inline: 1.5rem;
+}
+
 .card__title {
   font-weight: 700;
   color: var(--FONT-COLOR-CARD-TITLE);

--- a/css/style.css
+++ b/css/style.css
@@ -214,6 +214,7 @@ body {
 .card__content {
   padding-block-start: 2.25rem;
   padding-inline: 1.5rem;
+  padding-block-end: 2.25rem;
 }
 
 .card__title {
@@ -307,7 +308,7 @@ body {
   font-weight: 700;
   width: 100%;
   border-radius: 8px;
-  padding: 1.1em;
+  padding: 1.1em 1.1em 1em;
   user-select: none;
   cursor: pointer;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -64,6 +64,7 @@ ol {
   --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
+  --FONT-COLOR-CARD-LABEL: hsl(234, 29%, 20%);
   --COLOR-CARD-ICON: #ff6155;
 
   /* THEME TOGGLE COLORS */
@@ -249,6 +250,12 @@ body {
   color: var(--FONT-COLOR-CARD-LIST-TEXT);
   font-size: 1rem;
   line-height: 1.45;
+}
+
+.card__label {
+  color: var(--FONT-COLOR-CARD-LABEL);
+  font-weight: 700;
+  font-size: 0.75rem;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -211,6 +211,7 @@ body {
   font-weight: 700;
   color: var(--FONT-COLOR-CARD-TITLE);
   font-size: 2.5rem;
+  margin-block-end: 0.45em;
 }
 
 .card__description {

--- a/css/style.css
+++ b/css/style.css
@@ -226,6 +226,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 0.725em;
 }
 
 .card__list {
@@ -233,19 +234,20 @@ body {
   flex-direction: row;
   justify-content: flex-start;
   align-items: flex-start;
-  gap: 0.9em;
+  gap: 1em;
 }
 
 .card__icon {
   color: var(--COLOR-CARD-ICON);
-  width: 24px;
+  width: 100%;
+  max-width: 1.3125rem;
   height: auto;
 }
 
 .card__list-text {
   color: var(--FONT-COLOR-CARD-LIST-TEXT);
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -175,8 +175,6 @@ body {
 
 /** || MAIN */
 
-/** || FOOTER */
-
 /** || MEDIA QUERY (DEVICE WIDTH) */
 @media screen and (min-width: 23.4375rem) {
 }

--- a/css/style.css
+++ b/css/style.css
@@ -182,6 +182,13 @@ body {
   min-height: 100vh;
 }
 
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+}
+
 /** || MEDIA QUERY (DEVICE WIDTH) */
 @media screen and (min-width: 23.4375rem) {
 }

--- a/css/style.css
+++ b/css/style.css
@@ -220,6 +220,12 @@ body {
   line-height: 1.5;
 }
 
+.card__features {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 /** || MEDIA QUERY (DEVICE WIDTH) */
 @media screen and (min-width: 23.4375rem) {
 }

--- a/index.html
+++ b/index.html
@@ -144,9 +144,11 @@
             </ul>
 
             <form class="card__form">
-              <label class="card__label" for="email">Email address</label>
+              <div class="card__label-container">
+                <label class="card__label" for="email">Email address</label>
 
-              <span class="card__invalid hidden">Valid email required</span>
+                <span class="card__invalid hidden">Valid email required</span>
+              </div>
 
               <input
                 type="email"

--- a/js/modules/form.js
+++ b/js/modules/form.js
@@ -35,6 +35,11 @@ function handleSubmitForm() {
 export function initForm() {
   input.addEventListener("input", hideInvalidText);
 
+  input.addEventListener("invalid", (e) => {
+    e.preventDefault();
+    showInvalidText();
+  });
+
   form.addEventListener("submit", (e) => {
     e.preventDefault();
     handleSubmitForm();

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -59,7 +59,7 @@ const themeButtonHTML = `
         ></button>
 `;
 const listElements = document.querySelectorAll(".card__list");
-const checkIconSVG = `<svg class="card__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21"><g fill="none"><circle cx="10.5" cy="10.5" r="10.5" fill="#FF6155"/><path stroke="#FFF" stroke-width="2" d="M6 11.381 8.735 14 15 8"/></g></svg>`;
+const checkIconSVG = `<svg class="card__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21"><g fill="none"><circle cx="10.5" cy="10.5" r="10.5" fill="currentColor"/><path stroke="#FFF" stroke-width="2" d="M6 11.381 8.735 14 15 8"/></g></svg>`;
 const successIconSVG = ` <svg
             class="thanks__icon"
             aria-hidden="true"


### PR DESCRIPTION
## Description

Introduced the complete base mobile styling for the `.card` section, establishing its foundational structure, layout, and visual hierarchy. Also added the initial form validation behavior for the subscription input to handle invalid email feedback.  

## Changes

- Added base layout and visual styles for the `.card` container (background, width, padding, and spacing)
- Implemented base typography and spacing for `.card__title`, `.card__description`, and `.card__features`
- Styled `.card__list`, `.card__list-text`, and `.card__icon` for feature listings
- Created `.card__form` layout and added styles for `.card__label`, `.card__input`, `.card__subscribe`, and `.card__invalid`
- Added JS behavior for `.card__input` to show invalid feedback using the `invalid` event
- Adjusted placeholder color, input padding, and invalid label positioning
- Added temporary red text color for visibility during development (to be removed later)
- Repositioned the theme button for improved accessibility and visual alignment
- Minor spacing and margin adjustments for `.main__container` and overall content flow

## Screenshots

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Before screenshot](https://github.com/user-attachments/assets/5b5109fc-7247-43aa-a01f-460e71f7d569) | ![After screenshot](https://github.com/user-attachments/assets/95e0abec-a5c7-408d-93a4-fc27c192c1d4) |

## Notes for Reviewers

- This implementation is mobile-first and the tablet and desktop versions will follow in future PR's
- Please review the `.card__form` behavior and `.card__invalid` positioning to ensure proper alignment and visibility
- No breaking changes introduced
