### PR TITLE
feat: implement initial styling for thanks section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -88,33 +88,6 @@ ol {
   --BOX-SHADOW-THEME: 0 0 3px var(--SHADOW-COLOR-THEME);
 }
 
-/** || UTILITY CLASSES */
-.dark {
-  --BGCOLOR: #333;
-  /* ADD OTHER DARK COLOR THEME VARIABLES */
-
-  /* THEME TOGGLE COLORS */
-  --FONT-COLOR-THEME-ICON-DARK: #f1f1f1;
-  --BGCOLOR-THEME-BUTTON: #222;
-  --BGCOLOR-THEME-BUTTON-AFTER: #f1f1f1;
-  --BORDER-COLOR-THEME-BUTTON: #666;
-  --SHADOW-COLOR-THEME: rgba(255, 255, 255, 0.3);
-}
-
-.sr-only {
-  position: absolute;
-  left: -10000px;
-  width: 1px;
-  height: 1px;
-  top: auto;
-  overflow: hidden;
-}
-
-.hidden {
-  opacity: 0;
-  display: none;
-}
-
 /** || GENERAL STYLES */
 html {
   font-size: var(--FS);
@@ -317,6 +290,33 @@ body {
   padding: 1.1em 1.1em 1em;
   user-select: none;
   cursor: pointer;
+}
+
+/** || UTILITY CLASSES */
+.dark {
+  --BGCOLOR: #333;
+  /* ADD OTHER DARK COLOR THEME VARIABLES */
+
+  /* THEME TOGGLE COLORS */
+  --FONT-COLOR-THEME-ICON-DARK: #f1f1f1;
+  --BGCOLOR-THEME-BUTTON: #222;
+  --BGCOLOR-THEME-BUTTON-AFTER: #f1f1f1;
+  --BORDER-COLOR-THEME-BUTTON: #666;
+  --SHADOW-COLOR-THEME: rgba(255, 255, 255, 0.3);
+}
+
+.sr-only {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  top: auto;
+  overflow: hidden;
+}
+
+.hidden {
+  opacity: 0;
+  display: none;
 }
 
 /** || MEDIA QUERY (DEVICE WIDTH) */

--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,7 @@ ol {
   /* COLORS */
   --BGCOLOR-CARD: #fff;
   --BGCOLOR-CARD-SUBSCRIBE: hsl(234, 29%, 20%);
+  --BGCOLOR-THANKS: #fff;
   --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
@@ -290,6 +291,11 @@ body {
   padding: 1.1em 1.1em 1em;
   user-select: none;
   cursor: pointer;
+}
+
+.thanks {
+  background-color: var(--BGCOLOR-THANKS);
+  min-height: 100vh;
 }
 
 /** || UTILITY CLASSES */

--- a/css/style.css
+++ b/css/style.css
@@ -307,6 +307,7 @@ body {
   align-items: flex-start;
   padding-inline: 1.5em;
   padding-block-start: 9.3em;
+  padding-block-end: 2.5em;
 }
 
 .thanks__icon {

--- a/css/style.css
+++ b/css/style.css
@@ -63,6 +63,7 @@ ol {
   --BGCOLOR-CARD: #fff;
   --BGCOLOR-CARD-SUBSCRIBE: hsl(234, 29%, 20%);
   --BGCOLOR-THANKS: #fff;
+  --BGCOLOR-THANKS-DISMISS: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-CARD-DESCRIPTION: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-LIST-TEXT: hsl(235, 18%, 26%);
@@ -74,6 +75,7 @@ ol {
   --FONT-COLOR-THANKS-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-THANKS-CONTENT: hsl(235, 18%, 26%);
   --FONT-COLOR-THANKS-EMAIL: hsl(234, 29%, 20%);
+  --FONT-COLOR-THANKS-DISMISS: #fff;
   --COLOR-CARD-ICON: #ff6155;
   --BORDER-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
 
@@ -327,6 +329,17 @@ body {
 
 .thanks__email {
   color: var(--FONT-COLOR-THANKS-EMAIL);
+  font-weight: 700;
+}
+
+.thanks__dismiss {
+  background-color: var(--BGCOLOR-THANKS-DISMISS);
+  width: 100%;
+  padding: 1.075em;
+  border-radius: 8px;
+  user-select: none;
+  cursor: pointer;
+  color: var(--FONT-COLOR-THANKS-DISMISS);
   font-weight: 700;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -206,6 +206,7 @@ body {
 
 .card__picture {
   width: 100%;
+  max-width: 30.625rem;
 }
 
 .card__hero {

--- a/css/style.css
+++ b/css/style.css
@@ -316,6 +316,7 @@ body {
   font-weight: 700;
   font-size: 2.5rem;
   line-height: 1;
+  margin-block-end: 0.55em;
 }
 
 .thanks__content {

--- a/css/style.css
+++ b/css/style.css
@@ -300,7 +300,8 @@ body {
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
-  padding: 1.25em;
+  padding-inline: 1.5em;
+  padding-block-start: 9.3em;
 }
 
 /** || UTILITY CLASSES */

--- a/css/style.css
+++ b/css/style.css
@@ -296,6 +296,11 @@ body {
 .thanks {
   background-color: var(--BGCOLOR-THANKS);
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 1.25em;
 }
 
 /** || UTILITY CLASSES */

--- a/css/style.css
+++ b/css/style.css
@@ -72,6 +72,7 @@ ol {
   --FONT-COLOR-CARD-INPUT-PLACEHOLDER: hsl(0, 0%, 58%);
   --FONT-COLOR-CARD-SUBSCRIBE: #fff;
   --FONT-COLOR-THANKS-TITLE: hsl(234, 29%, 20%);
+  --FONT-COLOR-THANKS-CONTENT: hsl(235, 18%, 26%);
   --COLOR-CARD-ICON: #ff6155;
   --BORDER-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
 
@@ -314,6 +315,12 @@ body {
   font-weight: 700;
   font-size: 2.5rem;
   line-height: 1;
+}
+
+.thanks__content {
+  color: var(--FONT-COLOR-THANKS-CONTENT);
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 /** || UTILITY CLASSES */

--- a/css/style.css
+++ b/css/style.css
@@ -305,6 +305,10 @@ body {
   padding-block-start: 9.3em;
 }
 
+.thanks__icon {
+  margin-block-end: 2.3em;
+}
+
 .thanks__title {
   color: var(--FONT-COLOR-THANKS-TITLE);
   font-weight: 700;

--- a/css/style.css
+++ b/css/style.css
@@ -60,6 +60,7 @@ ol {
   --FS: 1rem;
 
   /* COLORS */
+  --BGCOLOR-MAIN: hsl(235, 18%, 26%);
   --BGCOLOR-CARD: #fff;
   --BGCOLOR-CARD-SUBSCRIBE: hsl(234, 29%, 20%);
   --BGCOLOR-THANKS: #fff;
@@ -165,12 +166,18 @@ body {
 }
 
 /** || MAIN */
+.main {
+  background-color: var(--BGCOLOR-MAIN);
+}
+
 .main__container {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
   min-height: 100vh;
+  max-width: 30.625rem;
+  margin-inline: auto;
 }
 
 .card {

--- a/css/style.css
+++ b/css/style.css
@@ -73,6 +73,7 @@ ol {
   --FONT-COLOR-CARD-SUBSCRIBE: #fff;
   --FONT-COLOR-THANKS-TITLE: hsl(234, 29%, 20%);
   --FONT-COLOR-THANKS-CONTENT: hsl(235, 18%, 26%);
+  --FONT-COLOR-THANKS-EMAIL: hsl(234, 29%, 20%);
   --COLOR-CARD-ICON: #ff6155;
   --BORDER-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
 
@@ -321,6 +322,11 @@ body {
   color: var(--FONT-COLOR-THANKS-CONTENT);
   font-weight: 400;
   line-height: 1.5;
+}
+
+.thanks__email {
+  color: var(--FONT-COLOR-THANKS-EMAIL);
+  font-weight: 700;
 }
 
 /** || UTILITY CLASSES */

--- a/css/style.css
+++ b/css/style.css
@@ -71,6 +71,7 @@ ol {
   --FONT-COLOR-CARD-INPUT: hsl(235, 18%, 26%);
   --FONT-COLOR-CARD-INPUT-PLACEHOLDER: hsl(0, 0%, 58%);
   --FONT-COLOR-CARD-SUBSCRIBE: #fff;
+  --FONT-COLOR-THANKS-TITLE: hsl(234, 29%, 20%);
   --COLOR-CARD-ICON: #ff6155;
   --BORDER-COLOR-CARD-INPUT: hsl(0, 0%, 58%);
 
@@ -302,6 +303,13 @@ body {
   align-items: flex-start;
   padding-inline: 1.5em;
   padding-block-start: 9.3em;
+}
+
+.thanks__title {
+  color: var(--FONT-COLOR-THANKS-TITLE);
+  font-weight: 700;
+  font-size: 2.5rem;
+  line-height: 1;
 }
 
 /** || UTILITY CLASSES */

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
             <p class="thanks__content">
               A confirmation email has been sent to
               <span class="thanks__email">ash@loremcompany.com</span>. Please
-              open it and click the button inside to confirm your subscription.
+              open it and click the button inside to confirm your subscription
             </p>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -167,13 +167,15 @@
         </section>
 
         <section class="thanks">
-          <h2 class="thanks__title">Thanks for subscribing!</h2>
+          <div class="thanks__wrapper">
+            <h2 class="thanks__title">Thanks for subscribing!</h2>
 
-          <p class="thanks__content">
-            A confirmation email has been sent to
-            <span class="thanks__email">ash@loremcompany.com</span>. Please open
-            it and click the button inside to confirm your subscription.
-          </p>
+            <p class="thanks__content">
+              A confirmation email has been sent to
+              <span class="thanks__email">ash@loremcompany.com</span>. Please
+              open it and click the button inside to confirm your subscription.
+            </p>
+          </div>
 
           <button class="thanks__dismiss" type="button">Dismiss message</button>
         </section>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 
     <main class="main" id="main">
       <div class="main__container">
-        <section class="card hidden">
+        <section class="card">
           <picture class="card__picture">
             <source
               media="(min-width: 64rem)"
@@ -166,7 +166,7 @@
           </div>
         </section>
 
-        <section class="thanks">
+        <section class="thanks hidden">
           <div class="thanks__wrapper">
             <h2 class="thanks__title">Thanks for subscribing!</h2>
 

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 
     <main class="main" id="main">
       <div class="main__container">
-        <section class="card">
+        <section class="card hidden">
           <picture class="card__picture">
             <source
               media="(min-width: 64rem)"
@@ -166,7 +166,7 @@
           </div>
         </section>
 
-        <section class="thanks hidden">
+        <section class="thanks">
           <h2 class="thanks__title">Thanks for subscribing!</h2>
 
           <p class="thanks__content">

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -83,7 +83,7 @@ const successIconSVG = ` <svg
               />
             </g>
           </svg>`;
-const thanksElement = document.querySelector(".thanks");
+const thanksWrapper = document.querySelector(".thanks__wrapper");
 
 function addThemeHTML() {
   theme.innerHTML = themeIconLightHTML + themeIconDarkHTML + themeButtonHTML;
@@ -96,7 +96,7 @@ function addCheckIconSVG() {
 }
 
 function addSuccessIconSVG() {
-  thanksElement.insertAdjacentHTML("afterbegin", successIconSVG);
+  thanksWrapper.insertAdjacentHTML("afterbegin", successIconSVG);
 }
 
 export function initUI() {


### PR DESCRIPTION
## Description

Implemented the initial styling and structure for the `.thanks` section of the site. It introduced a consistent layout, visual hierarchy, and responsive adjustments for the `.thanks` component and its child elements.  

## Changes

- Added base and spacing styles for all `.thanks` elements (`.thanks__icon`, `.thanks__title`, `.thanks__content`, `.thanks__email`, `.thanks__dismiss`)
- Updated `.thanks` layout to use Flexbox and applied `padding` and `max-width` constraints
- Wrapped content in `.thanks__wrapper` for better DOM structure and styling control
- Adjusted padding and margins for consistent spacing between sections
- Updated `.main__container` sizing and applied background color to `.main`
- Temporarily toggled visibility between `.card` and `.thanks` sections for styling verification
- Refactored CSS cascade by moving utility classes to the bottom
- Updated `ui.js` to select `.thanks__wrapper`

## Screenshots

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Before screenshot](https://github.com/user-attachments/assets/ec8102d8-c198-44c6-a0b0-0058ea0650c7) | ![After screenshot](https://github.com/user-attachments/assets/09606644-953e-4a07-980c-275931666cbf) |

## Notes for Reviewers

- Focus on verifying visual alignment, spacing, and responsive layout of the `.thanks` section  
- Non-breaking change, merge as soon as possible
