### PR TITLE
feat(css): add and refine tablet media query styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -460,7 +460,6 @@ body {
     min-height: auto;
     padding: 1.5rem;
     border-radius: 35px;
-    gap: 4.25em;
     box-shadow: var(--BOX-SHADOW-CARD);
   }
 }
@@ -471,6 +470,7 @@ body {
     padding-block: 1.5rem;
     padding-inline-start: 4rem;
     padding-inline-end: 1.25rem;
+    gap: 4.25em;
   }
 
   .card__picture {

--- a/css/style.css
+++ b/css/style.css
@@ -448,14 +448,6 @@ body {
 
 /** || MEDIA QUERY (DEVICE WIDTH) */
 @media screen and (min-width: 48rem) {
-  .card {
-    border-radius: 15px;
-    box-shadow: var(--BOX-SHADOW-CARD);
-  }
-}
-
-@media screen and (min-width: 64rem) {
-  /** || MAIN */
   .main__container {
     justify-content: center;
     margin-inline: auto;
@@ -463,14 +455,22 @@ body {
   }
 
   .card {
-    flex-direction: row;
+    flex-direction: column;
     align-items: flex-start;
     min-height: auto;
+    padding: 1.5rem;
+    border-radius: 35px;
+    gap: 4.25em;
+    box-shadow: var(--BOX-SHADOW-CARD);
+  }
+}
+
+@media screen and (min-width: 64rem) {
+  .card {
+    flex-direction: row;
     padding-block: 1.5rem;
     padding-inline-start: 4rem;
     padding-inline-end: 1.25rem;
-    border-radius: 35px;
-    gap: 4.25em;
   }
 
   .card__picture {


### PR DESCRIPTION
## Description

Introduced and refined responsive styles for tablet-sized screens.


## Changes

- Updated the media query for tablet-sized screens (`min-width: 64rem`)  
- Moved `gap` property into the tablet media query for better layout control  
- Adjusted layout spacing to maintain consistent design hierarchy across viewports

## Screenshots

| Tablet Version Before                          | Tablet Version After                        |
| -------------------------------- | ------------------------------- |
| ![Before screenshot](https://github.com/user-attachments/assets/43724402-ff67-40e8-9eee-8282ae5fb9e3) | ![After screenshot](https://github.com/user-attachments/assets/c78b362c-7046-4cc3-a200-4be768829eb5) |

## Notes for Reviewers

- Confirm layout spacing and alignment on tablet devices
- Non-breaking change, responsive enhancement only